### PR TITLE
deleting a load balancer does not return a JSON body

### DIFF
--- a/loadbalancers/request.go
+++ b/loadbalancers/request.go
@@ -76,9 +76,7 @@ func Delete(client *gophercloud.ServiceClient, id uint64) (r DeleteResult) {
 	url := client.ServiceURL("loadbalancers", strconv.FormatUint(id, 10))
 	log.Printf("DELETE %s", url)
 
-	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{
-		JSONResponse: &r.Body,
-	})
+	_, r.Err = client.Delete(url, &gophercloud.RequestOpts{})
 	return
 }
 


### PR DESCRIPTION
We will not get a JSON body when we attempt to delete a load balancer.
Instead we'll get a 20x code or a 40x code based on the validity of the
request.